### PR TITLE
fix: fix logo pic display problem in identity page

### DIFF
--- a/server/www/identity.html
+++ b/server/www/identity.html
@@ -158,7 +158,7 @@
             <div class="identifier-container">
                 <div>
                     <a href="//{{url_main}}" target="_blank">
-                        <img src="/assets/header.png">
+                        <img src="//{{url_main}}/assets/header.png">
                     </a>
                     <p class="speechbubble">
                         Your ID: <a class="identifier-hash" onclick="window.getSelection().selectAllChildren(this); document.execCommand('copy');">{{hash}}</a> <small>({{identifier}})</small>


### PR DESCRIPTION
`                    <a href="//{{url_main}}" target="_blank">
                        <img src="/assets/header.png">
                    </a>`
this element is on `DEMO_DOMAIN`, but the picture is on `MAIN_DOMAIN`, if the main domain is not on port 80, the pic will not display,