### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -91,7 +91,7 @@ let Webserver = (() => {
         }
         static getIdentifier(vector, size = vector.size) {
             return parseInt(this.routes.map((route) => vector.has(route) ? 0 : 1)
-                .join('').substr(0, size).split('').reverse().join(''), 2);
+                .join('').slice(0, size).split('').reverse().join(''), 2);
         }
         static hasRoute(route) {
             return this.routes.includes(route);

--- a/server/main.ts
+++ b/server/main.ts
@@ -137,7 +137,7 @@ class Webserver {
     }
     public static getIdentifier(vector: Set<string>, size: number = vector.size): number {
         return parseInt(this.routes.map((route: string) => vector.has(route) ? 0 : 1)
-            .join('').substr(0, size).split('').reverse().join(''), 2);
+            .join('').slice(0, size).split('').reverse().join(''), 2);
     }
     public static hasRoute(route: string): boolean {
         return this.routes.includes(route);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.